### PR TITLE
Rest api

### DIFF
--- a/src/Acf/RestApi.php
+++ b/src/Acf/RestApi.php
@@ -13,7 +13,7 @@ class RestApi {
 	 * Initiate the ACF Rest API functionality.
 	 */
 	public static function init() {
-		add_action( 'rest_api_init', [ __CLASS__ , 'register' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'register' ] );
 	}
 
 	/**
@@ -24,7 +24,7 @@ class RestApi {
 			register_rest_field(
 				'post' === $type ? get_post_types() : $type ,
 				self::FIELD_NAME,
-				[ 'get_callback'    => [ __CLASS__, 'get_' . $type . '_fields' ] ]
+				[ 'get_callback' => [ __CLASS__, 'get_' . $type . '_fields' ] ]
 			);
 		}
 	}

--- a/src/Acf/RestApi.php
+++ b/src/Acf/RestApi.php
@@ -1,0 +1,55 @@
+<?php namespace Lean\Acf;
+
+use Lean\Acf;
+
+/**
+ * Output ACF fields in the WP Rest API.
+ */
+class RestApi {
+
+	const FIELD_NAME = 'acf';
+
+	/**
+	 * Initiate the ACF Rest API functionality.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__ , 'register' ] );
+	}
+
+	/**
+	 * Register the field for all post types and users.
+	 */
+	public static function register() {
+		foreach ( [ 'post', 'user' ] as $type ) {
+			register_rest_field(
+				'post' === $type ? get_post_types() : $type ,
+				self::FIELD_NAME,
+				[ 'get_callback'    => [ __CLASS__, 'get_' . $type . '_fields' ] ]
+			);
+		}
+	}
+
+	/**
+	 * Get all ACF fields for the post.
+	 *
+	 * @param array 		   $object     The current object.
+	 * @param string 		   $field_name The field name.
+	 * @param \WP_REST_Request $request    The request.
+	 * @return array
+	 */
+	public static function get_post_fields( $object, $field_name, $request ) {
+		return Acf::get_post_field( $object['id'], false );
+	}
+
+	/**
+	 * Get all ACF fields for the user.
+	 *
+	 * @param array 		   $object     The current object.
+	 * @param string 		   $field_name The field name.
+	 * @param \WP_REST_Request $request    The request.
+	 * @return array
+	 */
+	public static function get_user_fields( $object, $field_name, $request ) {
+		return Acf::get_user_field( $object['id'] );
+	}
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Feature
- **What is the current behavior?** (You can also link to an open issue
  here)
  ACF fields pulled into custom posts endpoint
- **What is the new behavior (if this is a feature change)?**
  ACF fields can be added to the standard WP REST API posts endpoint
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
