### PR TITLE
Acf update

### DIFF
--- a/src/Acf.php
+++ b/src/Acf.php
@@ -230,12 +230,11 @@ class Acf {
 			// @codingStandardsIgnoreEnd
 			$title = empty( $groups ) ? false : $groups[0]->post_title;
 
-			// Patch for the new version of ACF Fields plugins >= 5.4.*
+			// Patch for the new version of ACF Fields plugins >= 5.4.*.
 			if ( ! $title ) {
 				$groups = acf_get_field_group( $group_id );
 				$title = empty( $groups ) ? false : $groups['title'];
 			}
-
 		}
 
 		if ( $title ) {

--- a/src/Acf.php
+++ b/src/Acf.php
@@ -222,13 +222,20 @@ class Acf {
 			} else {
 				$args['name'] = $group_id;
 			}
+
 			// Then try the db if not found in local.
 			// @codingStandardsIgnoreStart
 			// Ignore use WP_Query rule because we don't know if this will be a sub-query and hence create complications.
 			$groups = get_posts( $args );
 			// @codingStandardsIgnoreEnd
-
 			$title = empty( $groups ) ? false : $groups[0]->post_title;
+
+			// Patch for the new version of ACF Fields plugins >= 5.4.*
+			if ( ! $title ) {
+				$groups = acf_get_field_group( $group_id );
+				$title = empty( $groups ) ? false : $groups['title'];
+			}
+
 		}
 
 		if ( $title ) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)
  If the site uses ACF Pro >= 5.4 the group name is not found.
- **What is the new behavior (if this is a feature change)?**
  Group name is there for newer versions
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No, it's just a patch in case the group name is false.
- **Other information**:

At first I had a filter as suggested in the meeting, but I've found some disadvantages on this:
1. I don't think we have any project using lean that won't be using the new version of the ACF Plugin
2. If we do that, the default behaviour should be the legacy mode, so we would need to update all the projects in order to use the new one.
3. I didn't find a good place to add the filter (because the function where the group is called it's inside a for inside a lot of functions and I couldn't find the exact point to add the filter).

What do you think?

Thanks!!
