### PR TITLE
Fix wrong query being executed

### DIFF
--- a/src/Acf.php
+++ b/src/Acf.php
@@ -216,20 +216,22 @@ class Acf {
 			$title = $acf_local->groups[ $group_id ]['title'];
 
 		} else {
-			$args = [ 'post_type' => 'acf-field-group' ];
+			$args = [
+				'post_type' => 'acf-field-group',
+				'no_found_rows' => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields' => 'ids',
+			];
 			if ( is_numeric( $group_id ) ) {
 				$args['post__in'] = [ $group_id ];
 			} else {
 				$args['name'] = $group_id;
 			}
-			$args['no_found_rows'] = true;
-			$args['update_post_meta_cache'] = false;
-			$args['update_post_term_cache'] = false;
-			$args['fields'] = 'ids';
 
 			$groups = new \WP_Query( $args );
-			$acf_groups = empty( $groups->posts ) ? [] : $groups->posts;
-			$acf_id = (int) $acf_groups[0];
+			$acf_groups = is_array( $groups->posts ) ? $groups->posts : [];
+			$acf_id = empty( $acf_groups ) ? 0 : $acf_groups[0];
 			$title = get_the_title( $acf_id );
 
 			// Patch for the new version of ACF Fields plugins >= 5.4.*.

--- a/src/Acf.php
+++ b/src/Acf.php
@@ -218,17 +218,19 @@ class Acf {
 		} else {
 			$args = [ 'post_type' => 'acf-field-group' ];
 			if ( is_numeric( $group_id ) ) {
-				$args['id'] = $group_id;
+				$args['post__in'] = [ $group_id ];
 			} else {
 				$args['name'] = $group_id;
 			}
+			$args['no_found_rows'] = true;
+			$args['update_post_meta_cache'] = false;
+			$args['update_post_term_cache'] = false;
+			$args['fields'] = 'ids';
 
-			// Then try the db if not found in local.
-			// @codingStandardsIgnoreStart
-			// Ignore use WP_Query rule because we don't know if this will be a sub-query and hence create complications.
-			$groups = get_posts( $args );
-			// @codingStandardsIgnoreEnd
-			$title = empty( $groups ) ? false : $groups[0]->post_title;
+			$groups = new \WP_Query( $args );
+			$acf_groups = empty( $groups->posts ) ? [] : $groups->posts;
+			$acf_id = (int) $acf_groups[0];
+			$title = get_the_title( $acf_id );
 
 			// Patch for the new version of ACF Fields plugins >= 5.4.*.
 			if ( ! $title ) {


### PR DESCRIPTION
In some cases the ACF was getting a parent that was not part of the ACF layout
due the fact that was using a wrong parameter to get the correct ACF by ID.

Insted of using get_posts we changed to use WP_Query in order to be more releiable
and update the list of parameters required.